### PR TITLE
Remove arm64 from excluded architectures

### DIFF
--- a/TenPrintCover.xcodeproj/project.pbxproj
+++ b/TenPrintCover.xcodeproj/project.pbxproj
@@ -254,7 +254,6 @@
 		1112A8381A3247D2002B8CC1 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";


### PR DESCRIPTION
Removes arm64 from excluded architectures to support Xcode simulator support on M1 macs.